### PR TITLE
typo in command line argument

### DIFF
--- a/src/defiads/main.rs
+++ b/src/defiads/main.rs
@@ -84,7 +84,7 @@ pub fn main () {
             .value_name("NETWORK")
             .help("Set the used bitcoin network.")
             .takes_value(true)
-            .possible_values(&["bitcoin", "testnet", "regrest"])
+            .possible_values(&["bitcoin", "testnet", "regtest"])
             .default_value("testnet"))
         .arg(Arg::with_name("bitcoin-connections")
             .value_name("n")


### PR DESCRIPTION
found a typo when trying to test this myself. Incidentally, it's unclear to me how to generate some regtest coins withwhich to actually do some testing. Is that something that I need to do outside of defiads via some other rust library? or do we need to add a command (something like `get-coins-from-faucet` available in regtest mode only)?